### PR TITLE
🛠️ pyproject.toml -> Added Python version spec

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,6 +11,7 @@ packages = [
 ]
 
 [tool.poetry.dependencies]
+python = ">=3.8.1,<4.0"
 GeneralAgent = "^0.3.21"
 shapely = "^2.0.1"
 pymupdf = "^1.24.7"


### PR DESCRIPTION
Due to resolve these messages, I added and tested that line.

```
The current project's supported Python range (>=3.8) is not compatible with some of the required packages Python requirement:
  - generalagent requires Python >=3.8.1, so it will not be satisfied for Python >=3.8,<3.8.1
  - generalagent requires Python >=3.8.1, so it will not be satisfied for Python >=3.8,<3.8.1
  - generalagent requires Python >=3.8.1, so it will not be satisfied for Python >=3.8,<3.8.1

Because no versions of generalagent match >0.3.21,<0.3.22 || >0.3.22,<0.3.23 || >0.3.23,<0.4.0
 and generalagent (0.3.21) requires Python >=3.8.1, generalagent is forbidden.
And because generalagent (0.3.22) requires Python >=3.8.1, generalagent is forbidden.
So, because generalagent (0.3.23) requires Python >=3.8.1
 and gptpdf depends on GeneralAgent (^0.3.21), version solving failed.

  • Check your dependencies Python requirement: The Python requirement can be specified via the `python` or `markers` properties
    
    For generalagent, a possible solution would be to set the `python` property to ">=3.8.1"
    For generalagent, a possible solution would be to set the `python` property to ">=3.8.1"
    For generalagent, a possible solution would be to set the `python` property to ">=3.8.1"

    https://python-poetry.org/docs/dependency-specification/#python-restricted-dependencies,
    https://python-poetry.org/docs/dependency-specification/#using-environment-markers
seonghobae@DESKTOP-QK8NP45:~/gptpdf$ poetry update
Updating dependencies
Resolving dependencies... (1.0s)

The current project's supported Python range (>=3.8.1) is not compatible with some of the required packages Python requirement:
  - tinydb requires Python >=3.7,<4.0, so it will not be satisfied for Python >=4.0

Because no versions of generalagent match >0.3.21,<0.3.22 || >0.3.22,<0.3.23 || >0.3.23,<0.4.0
 and generalagent (0.3.21) depends on tinydb (>=4.8.0), generalagent (>=0.3.21,<0.3.22 || >0.3.22,<0.3.23 || >0.3.23,<0.4.0) requires tinydb (>=4.8.0).
And because generalagent (0.3.22) depends on tinydb (>=4.8.0)
 and generalagent (0.3.23) depends on tinydb (>=4.8.0), generalagent (>=0.3.21,<0.4.0) requires tinydb (>=4.8.0).
Because no versions of tinydb match >4.8.0
 and tinydb (4.8.0) requires Python >=3.7,<4.0, tinydb is forbidden.
Thus, generalagent is forbidden.
So, because gptpdf depends on GeneralAgent (^0.3.21), version solving failed.

  • Check your dependencies Python requirement: The Python requirement can be specified via the `python` or `markers` properties
    
    For tinydb, a possible solution would be to set the `python` property to ">=3.8.1,<4.0"

    https://python-poetry.org/docs/dependency-specification/#python-restricted-dependencies,
    https://python-poetry.org/docs/dependency-specification/#using-environment-markers
```