### PR TITLE
change the pdf_images dpi

### DIFF
--- a/gptpdf/parse.py
+++ b/gptpdf/parse.py
@@ -168,7 +168,7 @@ def _parse_pdf_to_images(pdf_path: str,dpi:int,output_dir: str = './') -> List[T
             page.draw_rect(text_rect, color=(1, 1, 1), fill=(1, 1, 1))
             # 插入带有白色背景的文字
             page.insert_text((text_x, text_y), name, fontsize=10, color=(1, 0, 0))
-        page_image_with_rects = page.get_pixmap(matrix=fitz.Matrix(3, 3))
+        page_image_with_rects = page.get_pixmap(matrix=fitz.Matrix(dpi/72, dpi/72))
         page_image = os.path.join(output_dir, f'{page_index}.png')
         page_image_with_rects.save(page_image)
         image_infos.append((page_image, rect_images))

--- a/test/test.py
+++ b/test/test.py
@@ -19,7 +19,7 @@ def test_use_api_key():
     api_key = os.getenv('OPENAI_API_KEY')
     base_url = os.getenv('OPENAI_API_BASE')
     # Manually provide OPENAI_API_KEY and OPEN_API_BASE
-    content, image_paths = parse_pdf(pdf_path, output_dir=output_dir, api_key=api_key, base_url=base_url, model='gpt-4o', gpt_worker=6)
+    content, image_paths = parse_pdf(pdf_path, output_dir=output_dir, api_key=api_key, base_url=base_url, model='gpt-4o', gpt_worker=6,dpi=1000)
     print(content)
     print(image_paths)
     # also output_dir/output.md is generated
@@ -50,7 +50,7 @@ def test_qwen_vl_max():
     base_url = "https://dashscope.aliyuncs.com/compatible-mode/v1"
     # Refer to: https://help.aliyun.com/zh/dashscope/developer-reference/compatibility-of-openai-with-dashscope
     model  = 'qwen-vl-max'
-    content, image_paths = parse_pdf(pdf_path, output_dir=output_dir, api_key=api_key, base_url=base_url, model=model, verbose=True, temperature=0.5, max_tokens=1000, top_p=0.9, frequency_penalty=1)
+    content, image_paths = parse_pdf(pdf_path, output_dir=output_dir, api_key=api_key, base_url=base_url, model=model, verbose=True, temperature=0.5, max_tokens=1000, top_p=0.9, frequency_penalty=1,dpi=1000)
     print(content)
     print(image_paths)
 


### PR DESCRIPTION
贡献：增加了解析图片的DPI函数
效果：解析到markdown的pdf图片分辨率得到了提升，并且可以手动修改
使用方法示例：
`    content, image_paths = parse_pdf(
        pdf_path, 
        output_dir=output_dir, 
        api_key=api_key, 
        base_url=base_url, 
        model=model, 
        verbose=True, 
        temperature=0.5, 
        max_tokens=1000, 
        top_p=0.9, 
        frequency_penalty=1,
        dpi=1000
    )`